### PR TITLE
Prisma wsl2 workaround

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,8 +1,9 @@
 version: '3.8'
 services:
-  db:
+  postgres_db:
     image: postgres:14.1-alpine
     restart: always
+    container_name: postgres_db
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -12,4 +13,3 @@ services:
       - modelersrift-db:/var/lib/postgresql/data
 volumes:
   modelersrift-db:
-    driver: local

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "pages/_app.tsx",
   "scripts": {
     "dev:next": "NODE_ENV=development next dev",
-    "dev:postgres": "docker-compose -f docker-compose-dev.yml up",
+    "dev:postgres": "docker-compose -f docker-compose-dev.yml up -d",
     "dev": "run-p dev:*",
+    "prisma:migrate": "bash prisma-migrate.sh",
     "analyze": "ANALYZE=true yarn build",
     "build::next": "next build",
     "build::prisma": "npx prisma generate",
@@ -17,6 +18,9 @@
     "bin": "ts-node -r dotenv/config --project tsconfig.node.json -r tsconfig-paths/register bin/index",
     "prettier": "npx prettier --write bin components lib pages styles types utils server",
     "tunnel": "cloudflared tunnel --config cloudflare.yaml run"
+  },
+  "comments": {
+    "prisma:migrate": "This command is needed in order to support wsl2 environments. Docker does not expose localhost on a wsl2 machine"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/prisma-migrate.sh
+++ b/prisma-migrate.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copy package.json to docker container
+docker cp ./package.json postgres_db:/package.json
+
+# Copy /prisma to docker container
+docker cp ./prisma postgres_db:/prisma
+
+# Copy .env to docker container
+docker cp ./.env postgres_db:/.env
+
+# Apply prisma migration
+docker exec -it postgres_db sh -c "apk add --no-cache npm && npm install -g prisma && npx prisma migrate dev --skip-generate"
+
+# Copy any migration changes to local
+docker cp postgres_db:/prisma/migrations ./prisma


### PR DESCRIPTION
# Summary
There was a problem where prisma could not connect to the docker container running our postgres db in dev.
This is only a problem on Windows + WSL2, works fine on Mac / Linux. 

Added a bash script that will connect to the docker container running the postgres db then run `prisma migrate dev`, then copy the migration files if any to the local `/prisma` directory.